### PR TITLE
Adding raw feedback when tests are running

### DIFF
--- a/packages/jux-ui/src/App.vue
+++ b/packages/jux-ui/src/App.vue
@@ -201,6 +201,11 @@ body * {
   top: 0px;
   z-index: 1;
 }
+.execution-summary .execution-status {
+  display: flex;
+  justify-content: space-around;
+  flex-grow: 1;
+}
 
 .file-execution-summary {
   display: flex;
@@ -211,6 +216,7 @@ body * {
 .execution-test-duration {
   color: gray;
   font-size: 0.8rem;
+  white-space: nowrap;
 }
 
 .execution-children {

--- a/packages/jux-ui/src/components/ElapsedTime.vue
+++ b/packages/jux-ui/src/components/ElapsedTime.vue
@@ -1,0 +1,24 @@
+<template>
+  <div>{{seconds}} sec</div>
+</template>
+<script>
+
+export default {
+  name: 'ElapsedTime',
+  props: ['start'],
+  data() {
+    return {
+      seconds: 0
+    }
+  },
+  mounted() {
+    setTimeout(this.updateTime, 1000)
+  },
+  methods: {
+    updateTime() {
+      this.seconds += 1
+      setTimeout(this.updateTime, 1000)
+    }
+  }
+}
+</script>

--- a/packages/jux-ui/src/components/ExecutionDuration.vue
+++ b/packages/jux-ui/src/components/ExecutionDuration.vue
@@ -1,5 +1,5 @@
 <template>
-    <span v-if="duration > 0" class="execution-test-duration">{{duration}} ms</span>
+    <span v-if="duration > 0" class="execution-test-duration">{{duration.toLocaleString()}} ms</span>
 </template>
 <script>
     export default {

--- a/packages/jux-ui/src/components/ExecutionStatus.vue
+++ b/packages/jux-ui/src/components/ExecutionStatus.vue
@@ -1,0 +1,24 @@
+<template>
+  <div class="execution-status">
+    <i v-if="isRunning" class="pi pi-spin pi-spinner" />
+    {{reporter?.status}}
+    <elapsed-time v-if="isRunning && reporter?.execution?.startTime" start="reporter?.execution?.startTime" />
+  </div>
+</template>
+<script>
+import ElapsedTime from '@/components/ElapsedTime'
+import ReporterStatusType from '@/store/ReporterStatusType'
+
+export default {
+  name: 'ExecutionStatus',
+  props: ['reporter'],
+  components: {
+    ElapsedTime,
+  },
+  computed: {
+    isRunning() {
+      return this.reporter?.status === ReporterStatusType.running
+    }
+  }
+}
+</script>

--- a/packages/jux-ui/src/components/ExecutionSummary.vue
+++ b/packages/jux-ui/src/components/ExecutionSummary.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="execution-summary">
-    <div>{{reporter?.status}}</div>
+    <execution-status :reporter="reporter" />
     <div class="counters">
       <div class="counter-box failed">
         {{result.numFailedTests}} failed
@@ -16,10 +16,14 @@
 </template>
 <script>
 import pluralize from 'pluralize'
+import ExecutionStatus from './ExecutionStatus'
 
 export default {
   name: 'ExecutionSummary',
   props: ['reporter'],
+  components: {
+    ExecutionStatus,
+  },
   computed: {
     result() {
       return this.reporter?.execution?.result || {}

--- a/packages/jux-ui/src/components/FileExecutionResultSummary.vue
+++ b/packages/jux-ui/src/components/FileExecutionResultSummary.vue
@@ -1,7 +1,9 @@
 <template>
-  <span class="count-failing">{{result.numFailingTests}}</span>
-  <span class="count-pending">{{result.numPendingTests}}</span>
-  <span class="count-passed">{{result.numPassingTests}}</span>
+  <div class="file-execution-summary">
+    <span class="count-failing">{{result.numFailingTests}}</span>
+  <!--  <span class="count-pending">{{result.numPendingTests}}</span>-->
+    <span class="count-passed">{{result.numPassingTests}}</span>
+  </div>
 </template>
 <script>
 export default {

--- a/packages/jux-ui/src/components/FilePath.vue
+++ b/packages/jux-ui/src/components/FilePath.vue
@@ -1,34 +1,36 @@
 <template>
-    <div>
+    <div :class="this.class">
         <i class="pi pi-angle-down" @click="$emit('toggle')" />
         <span class="file-path-folder">{{folder}}</span>
         <span class="file-path-name ">{{fileName}}</span>
     </div>
 </template>
 <script>
-    export default {
-      name: 'FilePath',
-      props: ['path', 'root'],
-      computed: {
-        folder() {
-          return this.path.slice(this.root.length, this.path.lastIndexOf('/') + 1)
-        },
-        fileName() {
-          return this.path.slice(this.path.lastIndexOf('/') + 1)
-        }
-      }
+export default {
+  name: 'FilePath',
+  props: ['path', 'root', 'class'],
+  computed: {
+    folder() {
+      return this.path.slice(this.root.length, this.path.lastIndexOf('/') + 1)
+    },
+    fileName() {
+      return this.path.slice(this.path.lastIndexOf('/') + 1)
     }
+  }
+}
 </script>
 <style>
 .pi-angle-down {
-    align-self: center;
-    padding-right: 1rem;
+  align-self: center;
+  padding-right: 1rem;
+  cursor: pointer;
 }
 .file-path-folder {
-    color: gray;
-    padding-right: 0.2rem;
+  font-size: 0.9rem;
+  color: gray;
+  padding-right: 0.2rem;
 }
 .file-path-name {
-   font-weight: bold;
+  font-weight: bold;
 }
 </style>

--- a/packages/jux-ui/src/components/TestsTree.vue
+++ b/packages/jux-ui/src/components/TestsTree.vue
@@ -1,9 +1,9 @@
 <template>
     <execution-summary :reporter="reporter" />
 
-    <div v-if="result">
+    <div>
         <ul class="test-files">
-            <li v-for="file in execution.files" :key="file.path">
+            <li v-for="file in execution?.files" :key="file.path">
                 <file-execution :file="file" @on-test-selected="testSelected" />
             </li>
         </ul>
@@ -56,24 +56,34 @@
 
 
 .test-files > li:first-child .file-execution-title {
-    border-top-left-radius: 5px;
-    border-top-right-radius: 5px;
+  border-top-left-radius: 5px;
+  border-top-right-radius: 5px;
 }
 .test-files > li:last-child .file-execution-title {
-    border-bottom-left-radius: 5px;
-    border-bottom-right-radius: 5px;
+  border-bottom-left-radius: 5px;
+  border-bottom-right-radius: 5px;
 }
 
 /* FileExecution */
 
 .file-execution-title {
-    line-height: 2rem;
-    background: #f3f3f3;
-    padding-left: 1rem;
-    padding-right: 1rem;
+  line-height: 2rem;
+  background: #f3f3f3;
+  padding-left: 1rem;
+  padding-right: 1rem;
 
-    display: flex;
-    justify-content: space-between;
+  display: flex;
+  /*justify-content: space-between;*/
+}
+.file-execution-title .file-path {
+  flex-grow: 1;
+}
+.file-execution-title .pi-spinner {
+  width: 1rem;
+  height: 1rem;
+  align-self: center;
+  color: darkgray;
+  margin-right: 0.5rem;
 }
 .file-execution-elements {
   padding-right: 0.5rem;


### PR DESCRIPTION
The UI sucks but at least now we can see which files it is running and start to check tests without having to wait for all of them to pass.

![jux-feedback-while-running](https://user-images.githubusercontent.com/4428120/119516067-cd08c400-bd4c-11eb-9cbb-7a23bfbb47f9.gif)
